### PR TITLE
Remove binary image support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Removed
+
+- Remove binary image support.
+
 ## 0.3.0
 
 ### Added

--- a/schema.oas.yml
+++ b/schema.oas.yml
@@ -138,11 +138,8 @@ paths:
                 description:
                   type: string
                 image:
-                  oneOf:
-                    - type: string
-                      format: base64
-                    - type: string
-                      format: binary
+                  type: string
+                  format: base64
                 name:
                   type: string
                 title:


### PR DESCRIPTION
This is because some components don't support this feature yet 😩
(e.g. openapi-generator for Rust)